### PR TITLE
Postpone election by a month

### DIFF
--- a/announcements/20200720.md
+++ b/announcements/20200720.md
@@ -58,10 +58,10 @@ information you would like to make available to the voters to make them
 vote for you.
 
 The period to submit your nominations will start with this announcement
-and will last until midnight UTC, August 2nd 2020.
+and will last until midnight UTC, September 6th 2020.
 
 This will be followed by a period of two weeks in which voting can be
-done, so the voting will close by midnight UTC, August 16th 2020.
+done, so the voting will close by midnight UTC, September 20th 2020.
 
 A formatted email template will be provided which voters can use to
 assign a value of 1 through 5 to each of the candidates of their


### PR DESCRIPTION
I propose to postpone nomination till Sep 6, and election till Sep 20.

Here is my reasoning:

- The summer time isn't the best period for any kind of election because it's the vacation time in many countries.
- The pace of events sourrounding the bootstrapping process of The Raku Steering Council is so high that some if not many community members could still remain uninformed about it.