### PR TITLE
Minor formatting changes for Markdown

### DIFF
--- a/announcements/20201030.md
+++ b/announcements/20201030.md
@@ -1,13 +1,12 @@
 It is with great sorrow that the Raku Steering Council announces the ejection of a Raku core team member and Raku Steering Council member: Aleks-Daniel Jakimenko-Aleksejev.
 
-According to:
-https://github.com/Raku/Raku-Steering-Council/blob/main/papers/Raku_Steering_Council_Code.md#ejecting-core-team-members
+According to the [Raku Steering Council Code](https://github.com/Raku/Raku-Steering-Council/blob/main/papers/Raku_Steering_Council_Code.md#ejecting-core-team-members)
 
-"Ejecting core team members
-
-In exceptional circumstances, it may be necessary to remove someone from the core team against their will [...]. This can be accomplished by a Steering Council vote, but unlike other Steering Council votes, this requires at least a two-thirds majority. With 7 members voting, this means that a 4:3 vote is insufficient; 5:2 in favor is the minimum required for such a vote to succeed. [...]
-
-If the ejected core team member is also on the Steering Council, then they are removed from the Steering Council as well."
+> Ejecting core team members
+> 
+> In exceptional circumstances, it may be necessary to remove someone from the core team against their will [...]. This can be accomplished by a Steering Council vote, but unlike other Steering Council votes, this requires at least a two-thirds majority. With 7 members voting, this means that a 4:3 vote is insufficient; 5:2 in favor is the minimum required for such a vote to succeed. [...]
+> 
+> If the ejected core team member is also on the Steering Council, then they are removed from the Steering Council as well.
 
 Aleks-Daniel has been a great supporter of Raku in the past.  Some of his contributions were:
 - having been responsible for setting up the problem-solving repo.
@@ -18,11 +17,11 @@ Over time, apparently not agreeing with the direction of the Raku project, his b
 
 For that reason, Elizabeth Mattijsen initiated a voting procedure in the RSC.  Since she was the initiator of the procedure, she also added herself as an option for eviction:
 
-"Please indicate the people to be evicted from the Raku core team as well as from the Raku Steering Council:
-
-    [ ] Elizabeth Mattijsen
-
-    [ ] Aleks-Daniel Jakimenko-Aleksejev"
+> Please indicate the people to be evicted from the Raku core team as well as from the Raku Steering Council:
+> 
+>     [ ] Elizabeth Mattijsen
+> 
+>     [ ] Aleks-Daniel Jakimenko-Aleksejev"
 
 
 The council has taken a vote and the result is: 6 votes received, 1 abstention noted.

--- a/announcements/20201030.md
+++ b/announcements/20201030.md
@@ -1,6 +1,6 @@
 It is with great sorrow that the Raku Steering Council announces the ejection of a Raku core team member and Raku Steering Council member: Aleks-Daniel Jakimenko-Aleksejev.
 
-According to the [Raku Steering Council Code](https://github.com/Raku/Raku-Steering-Council/blob/main/papers/Raku_Steering_Council_Code.md#ejecting-core-team-members)
+According to the [Raku Steering Council Code](https://github.com/Raku/Raku-Steering-Council/blob/main/papers/Raku_Steering_Council_Code.md#ejecting-core-team-members):
 
 > Ejecting core team members
 > 


### PR DESCRIPTION
This PR changes the plaintext link to a Markdown link and the two longer quotes into Markdown block quotes.

Neither of these change the substance at all, but make the presentation a bit cleaner.