### PR TITLE
Add code of conduct and incident response guide

### DIFF
--- a/papers/coc_incident_response_guide.md
+++ b/papers/coc_incident_response_guide.md
@@ -1,0 +1,244 @@
+Raku CoC Incident Response Guide
+================================
+
+This document describes the Raku Code of Conduct enforcement
+procedures in general terms but is not intended to be binding or to
+create any rights; in all cases, ensuring that the Raku community is
+welcoming, inclusive, safe, and enjoyable for all ("-Ofun") should
+take priority over strictly following the procedures described below.
+
+This guide is not legal advice.
+
+Before Taking Action
+====================
+
+The CoC is enforced by the Raku Community Affairs Team (currently
+comprised of the members of the Raku Steering Council).
+
+When the CAT receives a report of a CoC violation, any members who are
+the subject of the report or who have an actual or apparent conflict
+of interest shall immediately be recused and will neither participate
+in further actions nor access information about the report or the
+CAT's response.
+
+Barring extraordinary circumstances, the CAT will act on all reports
+within 72 hours of first receiving the report.  The CAT will act by
+majority vote and, if practicable, should hold a synchronous meeting
+(e.g., a video call) with at least 3 attendees to vote on its action.
+However, due to the importance of promptly responding to reports, the
+CAT may also act via asynchronous discussion and voting (e.g., over
+email).  If it does so, it may set a deadline after which failure to
+cast an explicit vote will be treated as an abstention.
+
+Investigating the Incident
+--------------------------
+
+In some cases (especially those involving in-person conduct), the CAT
+may investigate the incident, such as by having one or more members
+speak with the reporter, the alleged violator, or others present at
+the incident.  In other cases (especially those where a violation was
+recorded, such as in an IRC log or recorded conference presentation),
+no such investigation will be necessary.
+
+When considering alleged violations, the CAT should bear in mind that it
+lacks the resources of the formal legal system and that the actions it
+takes inflict far less harm than those taken by the legal system.
+Accordingly, the CAT should not attempt to determine whether a violation
+has been proven beyond a reasonable doubt. Instead, it should ask what
+action best promotes an -Ofun community based on the facts as they
+appear.
+
+Similarly, the lower severity of the remedies available to the CAT mean
+that alleged violators need not receive any of the procedural
+protections criminal defendants are entitled to, such as the right to
+speak in their defense.  Accordingly, it is especially important that
+the CAT remember that determining guilt and assigning punishment are
+_not_ within its purview; the CAT's only job is to make decisions that
+will make the Raku community as -Ofun as possible.
+
+Additionally, the CAT should remember that the violator's intent
+(which may be impossible to accurately determine) is generally not
+relevant; instead, the CAT should focus on the impact the incident
+had, and the impact that other, similar events could be expected to
+have.
+
+If its investigations into an incident reveal other CoC violations
+that were not reported (e.g., an IRC argument in which multiple people
+engaged in personal attacks but only one was reported), the CAT should
+also evaluate those violations and take appropriate actions.
+
+Responding to the Incident
+==========================
+
+After reviewing the incident, the CAT should determine what action to
+take in response.  When making this determination, the CAT should
+consult records of previous violations, both to see whether the violator
+has a history of poor behavior and to ensure that similar violations
+receive proportional responses.
+
+Because CoC violations by members of the Raku Steering Council and
+others in positions of trust or authority within the Raku community are
+especially harmful, these individuals are appropriately held to an even
+higher standard than other community members.  The CAT should consider
+this higher standard when deciding what action to take when someone in
+that group has violated the CoC.
+
+Allowed Responses
+-----------------
+
+The CAT can respond to reports with any of the following actions or with
+any other action it deems appropriate:
+
+* Determining that the conduct did not violate the CoC or that no action
+  is needed.
+* Determining that the incident requires additional investigation.
+* Speaking to the violator informally.
+* Editing or redacting media (such as the video of a conference talk)
+  that contains the violation. 
+* Removing media that contains the violation.
+* Officially warning the violator.
+* Temporarily banning the violator from one or more Raku community
+  spaces.
+* Publicly reprimanding the violator.
+* Permanently banning the violator from one or more Raku community
+  spaces.
+* Recommending that the Raku Steering Council eject the violator from the
+  Raku core team.
+* Recommending that the Raku Steering Council eject the violator from the
+  Raku core team and permanently banning them from the Raku community.
+
+Disallowed Responses
+--------------------
+
+While the CAT can take appropriate actions other than those listed
+above, it should _not_ take any of the following inappropriate actions:
+
+* Requiring the violator to apologize (voluntary apologies are sometimes
+  helpful; coerced apologies never are).
+* Asking or requiring the target of the violation to decide on or
+  approve the action (this shifts blame to the target; the decision is
+  the CAT's responsibility).
+* Requiring the violator to avoid the target (this is logistically
+  unworkable without unfairly burdening the target's privacy and invites
+  future conflict).
+* Assigning someone to "chaperone" or otherwise supervise the violator
+  (this is unfair and logistically unworkable; if the CAT is concerned
+  enough about future violations to consider this response, it should
+  ban the violator instead).
+
+A Note on Mediation
+-------------------
+
+The CAT should not require mediation, nor should it recommend mediation
+as an action it takes in response to a CoC violation.  This is because
+violating the CoC is an action that harms the entire Raku community;
+reframing the CoC violation as an interpersonal conflict is
+inappropriate and suggests that the target of the violation is partly or
+equally responsible for the violation.  This is incorrect: it is
+perfectly possible for two people to dislike each other without either
+violating the CoC.
+
+However, it is equally the case that continued interpersonal conflict or
+animosity could lead to future CoC violations and, even if it doesn't,
+makes the Raku community less -Ofun.  Thus, if the CAT identifies an
+underlying interpersonal conflict or cross-cultural misunderstanding, it
+can be appropriate for the CAT to offer mediation _after and separate
+from_ its resolution of the violation.  If the CAT offers mediation, it
+should state clearly that mediation is not required and is not a
+response that the CAT is taking based on the CoC violation but rather is
+a service the CAT is offering to help resolve an underlying
+interpersonal or cross-cultural issue.  Mediation should _never_ be
+offered if the violation is extremely serious (e.g., harassment).
+
+After Taking Action
+===================
+
+In all cases, the CAT will inform the reporter how the report was
+resolved and may inform others who witnessed the incident.  When
+deciding whom to inform, the CAT should keep in mind that, if a
+bystander is not informed that action was taken based on a CoC
+violation, they may conclude that the Raku community permits behavior
+of the sort they witnessed.
+
+The CAT will preserve records of the incident including, at a minimum,
+the initial report and a record of any action that was taken (including
+informal conversations with the violator).  The CAT will ensure that
+these records are accessible to the CAT when addressing future reports
+but are not accessible to non-members.
+
+At least annually, the CAT will publish a summary of all reported
+incidents and any actions taken in response to those incidents; it may
+publish reports (either of multiple actions or a single action) more
+frequently based on their number or severity.  Except in cases where
+naming the violator is essential to the action (e.g., a public
+reprimand), the CAT will endeavor not to name violators and will not
+name reporters.  However, the nature of an incident may make the
+identity of one or both parties obvious (for example, if the incident
+occurred in a publicly logged IRC channel).
+
+When summarizing an incident, the CAT should avoid going into more
+detail than necessary to fairly inform the community of the incident.
+Additionally, the CAT should recall that the identity of any party may
+become known even if that party isn't named in the summary, and the CAT
+should be especially careful to avoid descriptions of the event that
+risk creating misleading impressions of the violation's severity.  If
+factual disputes about the incident exist, the CAT should avoid creating
+the impression of greater certainty about the facts than exists.  If a
+violator cannot be identified, then the incident summary should state
+what action the CAT would have taken if the violator had been
+identified.
+
+The following incident description from the [Conference in the Cloud
+2020 SoC Transparency
+Report](https://news.perlfoundation.org/post/cic-2020-soc-transparency-report)
+provides an example of the appropriate level of detail:
+
+> Slides for a talk were reported as containing inappropriate
+> material. The CAT reviewed the recording of the talk and agreed that
+> this was the case. The CAT talked with the speaker, explaining the
+> issue and the consequences. The speaker was given a final warning.
+
+Whenever the CAT publishes a summary of any incidents or otherwise
+communicates publicly, it shall establish an appropriate venue for
+discussion (e.g., a GitHub issue) and shall request that all discussion
+about the incidents be limited to that venue or sent directly to the CAT
+via email.  It shall also state that discussion of the incident or
+debate about the appropriate response to it is off topic in all other
+Raku spaces and may itself be a CoC violation.
+
+(The reason for this restriction is that defenses of violations can
+often do more to make a community non-inclusive than the initial
+violation itself, especially when those debates occur in spaces that are
+impractical for community members to avoid (such as #raku).  It is
+essential that there be a space for the community to debate and
+criticize the CAT's actions, but it's also essential that this space be
+an opt-in one.)
+
+If community discussion reveals significant confusion or
+misunderstanding about a factual issue, the CAT may issue _one_ follow
+up communication about the incident.  When doing so, it should keep the
+following rules (from [How to Respond to Code of Conduct
+Reports](https://frameshiftconsulting.com/code-of-conduct-book/)) in
+mind:
+
+* Do not try to persuade people who strongly disagree with you
+* Wait to see how people react to the initial announcement
+* If necessary, post one follow-up to clarify any genuine
+  misunderstandings
+* Refuse to provide more details about the incident or its handling
+* Refuse to engage in one-on-one arguments, online or in person
+* Redirect any community-wide discussions into smaller venues
+
+Regardless of whether the CAT issues a follow-up communication, it must
+not edit the original communication in any way, except that it may
+optionally add a single clearly labeled edit linking to the follow-up
+communication.
+
+For additional guidance (including guidance on handling more severe
+incidents), the CAT may refer to [How to Respond to Code of Conduct
+Reports](https://frameshiftconsulting.com/code-of-conduct-book/).  If
+doing so would be helpful, the CAT may also consult with the Community
+Affairs Team or Legal Committee at Yet Another Society or with other
+outside advisors.
+
+

--- a/papers/code_of_conduct.md
+++ b/papers/code_of_conduct.md
@@ -1,0 +1,174 @@
+Raku Code of Conduct
+====================
+
+The Raku community is committed to providing a welcoming, inclusive,
+safe, and enjoyable environment for everyone.  In fact, we have a term
+for a "welcoming, inclusive, safe, and enjoyable for all": we say that
+the Raku community should be "optimized for fun" – or, in short form,
+"-Ofun".  Using that terminology, we are committed to ensuring that the
+Raku community is -Ofun for everyone, regardless of level of experience,
+gender identity and expression, sexual orientation, disability,
+neurodiversity, personal appearance, body size, race, ethnicity, age,
+religion, nationality, or other similar characteristic.
+
+Many people have eloquently described the -Ofun community culture to
+which we aspire.  In the interest of clarity and concision, this
+document does not do so; instead, it provides a short, readable list of
+unacceptable behaviors so that we're all on the same page about the
+ground rules in our particular community.
+
+The purpose of this CoC is _exclusively_ to ensure that the Raku
+community is -Ofun (welcoming, inclusive, safe, and enjoyable for all).
+This CoC is not designed to punish wrongdoers, mediate arguments, or
+improve the morality of community members.  Those goals may be worthy
+but are outside the scope of this document.
+
+Unacceptable Behaviors
+======================
+
+The following behaviors, in no particular order, are unacceptable and
+violate the Code of Conduct.
+
+* Using sexist, racist, homophobic, transphobic, ableist, or otherwise
+  discriminatory language (including repeated/deliberate misgendering or
+  deadnaming).
+* Using insults, profanity targeting a person, personal or political
+  attacks, or other gratuitously hurtful language (if in doubt,
+  criticize ideas or behavior instead of people).
+* Repeatedly involving someone in a conversation or topic (for example,
+  by sending them emails or chat notifications) despite their
+  objection.
+* Continuing or repeatedly starting a conversation in an inappropriate
+  venue (for example, debating the merits of a Code of Conduct violation
+  in the general #raku IRC channel rather than in the appropriate GitHub
+  issue or repeated off-topic conversations in #raku-dev).
+* Posting or displaying sexually explicit or graphically violent images
+  or using sexually explicit language or excessive profanity.
+* Making inappropriate sexual advances.
+* Stalking (online or in person) or inappropriate photography/recording.
+* Revealing, or threatening to reveal, someone's contact information or
+  other non-public data ("doxing") or sharing private content, such as
+  non-public emails or channel history from unlogged IRC channels,
+  without consent.
+* Any public or private harassment.
+* Refusing to agree to follow the existing CoC (arguing that the CoC
+  should be changed is fine when done in an appropriate venue; refusing
+  to follow the exiting CoC is not).
+* Falsely reporting a CoC violation in bad faith.
+
+Non Defenses
+============
+
+The following "justifications" do _not_ excuse violating the Code of
+Conduct:
+
+* "They started it": When someone violates the CoC, speaking to them
+  about their behavior or reporting the behavior may be appropriate,
+  depending on the circumstances.  However, no circumstances justify
+  responding in a way that itself violates the CoC.  It is entirely
+  possible for multiple people in a conversation to violate the CoC;
+  one person's CoC violations in no way offset the other's.
+* "I didn't mean to": Intent may be relevant to determining the
+  _severity_ of a CoC violation – malicious intent certainly makes
+  harmful conduct worse.  But intent is typically _not_ relevant to
+  determining whether conduct violates the CoC.  Instead, whether
+  behavior violates the CoC is determined entirely by the impact that
+  behavior had (and could be reasonably expected to have had).  Good
+  intent does not excuse harmful impact.
+* "It's free speech": A huge number of statements are both lawful and
+  totally unwelcome in the Raku community; speech laws of any
+  jurisdiction are entirely irrelevant to determining whether particular
+  conduct violates the CoC.
+* "It's just a tone issue": In some communities, ideas are the only
+  thing that matters – if the substance of an idea is correct, then the
+  way that idea is expressed is irrelevant.  The Raku community is not
+  like that.  In the Raku community, tone matters: forceful criticism of
+  someone's ideas or behavior can be perfectly in keeping with the CoC
+  if expressed one way; the same ideas, expressed as a personal attack,
+  would violate the CoC.
+* "That doesn't count because it was on a personal blog": As explained
+  below, personal blogs, social media profiles, and similar spaces are
+  _not_ covered by the CoC; however, the Raku community can still respond
+  to content or behavior in those spaces if that content/behavior makes
+  complying with the CoC in Raku spaces unlikely or impossible.  This is
+  because enforcing the CoC is never a punitive act; it is always about
+  ensuring that the Raku community is -Ofun.  For instance, the Raku
+  community would be neither inclusive nor enjoyable if it welcomed
+  people who post racist screeds to their personal sites, no matter how
+  assiduously they attempted to separate those statements from their
+  Raku activities.
+* "You'll never prove it": The CoC is not a code of law, and enforcing
+  it does not require proving that any particular violation definitely
+  took place (much less proving it by the standards of a criminal
+  court).  All it requires is that the response to an incident help make
+  the Raku community -Ofun.
+
+Covered Spaces
+==============
+
+This CoC applies to the #raku, #raku-dev, and #moarvm IRC channels; the
+GitHub repositories under the Raku, Rakudo, and MoarVM organizations;
+the perl6/Raku mailing lists; the Raku Discord channel; the r/rakulang
+subreddit; posts to Rakudo Weekly News; blogs posted to Planet Raku; and
+any other digital spaces Raku may establish.  It also applies to all
+official Raku conferences and events, physical or digital.
+
+Modification
+============
+The Raku Steering Council may revise this CoC by majority vote.  Any 
+revisions will have purely prospective effect.
+
+Enforcement
+===========
+
+The CoC will be enforced by the Community Affairs Team (excluding any
+recused members) as described in the [CoC Incident Response
+Guide](./coc_incident_response_guide.md).  The CAT will make every
+effort to respond within 72 hours of receiving a report; if a violation
+occurred, the CAT may respond by a range of actions from informally
+discussing the incident with the violator to permanently banning the
+violator from Raku community spaces and recommending that the Raku
+Steering Council eject them from the core team.  Please see the [CoC
+Incident Response
+Guide](./coc_incident_response_guide.md#allowed-responses) for details.
+
+Reporting Violations
+====================
+
+If you were subject to or witnessed a CoC violation, you should report
+it to CAT@raku.org.  Alternatively, you can report a violation to any
+member of the CAT, who will forward it to all non-recused members of the
+CAT.  Please be aware that, while the CAT will make all reasonable
+efforts not to disclose the identity of individuals who report
+violations, it cannot guarantee reporter anonymity nor do reporters have
+a way to lessen or otherwise alter the action the CAT takes based on a
+report.
+
+Credits & Sources
+=================
+
+This CoC draws heavily on the ideas in the book [How to Respond to Code
+of Conduct Reports](https://frameshiftconsulting.com/code-of-conduct-book/) and
+sources cited in that book (especially [How "Good Intent" Undermines
+Diversity and Inclusion](https://thebias.com/2017/09/26/how-good-intent-undermines-diversity-and-inclusion/)
+and [No More Rock Stars: How to Stop Abuse in Tech
+Communities](https://hypatia.ca/2016/06/21/no-more-rock-stars/)).
+
+Additionally, this CoC was inspired by/was written with reference to the following codes of
+conduct:
+[Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct.html),
+[Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md),
+[Code for America's Code of Conduct](https://github.com/codeforamerica/codeofconduct/blob/master/code-of-conduct-en.md),
+[Conference in the Cloud – Standards of Conduct](https://perlconference.us/tpc-2020-cloud/standards-of-conduct/),
+[Conference in the Cloud – Handling Standards of Conduct Incidents](https://perlconference.us/tpc-2020-cloud/handling-standards-of-conduct-incidents/),
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct/),
+[Django Code of Conduct](https://www.djangoproject.com/conduct/),
+[Explorations in RL 2019 Code of Conduct](https://sites.google.com/view/erl-2019/code-of-conduct),
+[Geek Feminism Code of Conduct](https://geekfeminismdotorg.wordpress.com/about/code-of-conduct/),
+[Geek Feminism Community Anti-Harassment Policy](https://geekfeminism.wikia.org/wiki/Community_anti-harassment/Policy),
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/),
+[Python Community Code of Conduct](https://www.python.org/psf/conduct/),
+[Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
+[StackOverflow Code of Conduct](https://stackoverflow.com/conduct),
+and
+[The Technology Transformation Service Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md).


### PR DESCRIPTION
The Code of Conduct and Incident Response Guide were both recently adopted in the Raku Problem Solving repository (Raku/problem-solving#261), and thus are official Raku papers.