### PR TITLE
Explicitly list newly created digital spaces

### DIFF
--- a/papers/Raku_Code_of_Conduct.md
+++ b/papers/Raku_Code_of_Conduct.md
@@ -109,10 +109,11 @@ Covered Spaces
 This CoC applies to the `#raku`, `#raku-dev`, and `#moarvm` IRC
 channels; the GitHub repositories under the Raku, Rakudo, and MoarVM
 organizations; the perl6/Raku mailing lists; the Raku Discord channel;
-the r/rakulang subreddit; posts to Rakudo Weekly News; blogs posted to
-Planet Raku; and any other digital spaces Raku may establish.  It also
-applies to all official Raku conferences and events, physical or
-digital.
+the r/rakulang subreddit; Rakudo Weekly News; Planet Raku blogs; the 
+Raku dev.to organization; the Rakulang YouTube channel; the 
+rakulang@<!-- -->fosstodon.org Mastodon account; and any other digital spaces
+Raku may establish.  It also applies to all official Raku conferences
+and events, physical or digital.
 
 Modification
 ============


### PR DESCRIPTION
This adds three newly created Raku digital spaces (dev.to, YouTube, & Mastodon) to the explicit list of covered spaces.  This change is  non-substantive: these spaces were already covered by the "any other digital spaces Raku may establish" clause.  But it's good to be explicit.