### PR TITLE
Announcement of JJ's resignation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,5 @@ The current Raku Steering council members are (in alphabetical order):
 - Geoffrey Broadwell
 - Nick Logan
 - Elizabeth Mattijsen
-- JJ Merelo
 - Stefan Seifert
 - Daniel Sockwell

--- a/announcements/20230122.md
+++ b/announcements/20230122.md
@@ -1,0 +1,7 @@
+## Thanking JJ Merelo
+
+The Raku Steering Council announces, with sadness and gratitude, that JJ Merelo
+has resigned from the Raku Steering Council and the Raku Community Affairs team
+due to limited availability. JJ has served on both the RSC and the CAT since
+their inception; his insightful perspective and compassionate approach will be
+greatly missed.  The RSC thanks JJ for his service.

--- a/papers/cat_membership.md
+++ b/papers/cat_membership.md
@@ -3,6 +3,5 @@ The current members of the Raku Community Affairs Team are (in alphabetical orde
     Vadim Belman
     Geoffrey Broadwell
     Nick Logan
-    JJ Merelo
     Stefan Seifert
     Daniel Sockwell


### PR DESCRIPTION
This PR adds an announcement stating that @JJ is steeping down from the RSC/CAT due to a lack of time.  It also removes JJ from the membership list for both groups.